### PR TITLE
Switch to Custom Elements v1 and drop support for v0.

### DIFF
--- a/.scripts/transpile.sh
+++ b/.scripts/transpile.sh
@@ -1,2 +1,2 @@
 # TODO --watch mode
-buble -i ./src -o ./esmodule --no modules --yes dangerousForOf --target ie:11 --objectAssign "Object.assign" -m inline
+buble -i ./src -o ./esmodule --no modules --yes dangerousForOf --target edge:13 --objectAssign "Object.assign" -m inline

--- a/src/core/ElementManager.js
+++ b/src/core/ElementManager.js
@@ -83,24 +83,11 @@ class ElementManager {
      * Apply the DOMMatrix value to the style of this Node's element.
      */
     applyTransform (domMatrix) {
-        var cssMatrixString = `matrix3d(
-            ${ domMatrix.m11 },
-            ${ domMatrix.m12 },
-            ${ domMatrix.m13 },
-            ${ domMatrix.m14 },
-            ${ domMatrix.m21 },
-            ${ domMatrix.m22 },
-            ${ domMatrix.m23 },
-            ${ domMatrix.m24 },
-            ${ domMatrix.m31 },
-            ${ domMatrix.m32 },
-            ${ domMatrix.m33 },
-            ${ domMatrix.m34 },
-            ${ domMatrix.m41 },
-            ${ domMatrix.m42 },
-            ${ domMatrix.m43 },
-            ${ domMatrix.m44 }
-        )`;
+
+        // for now, template strings need to be on one line, otherwise Meteor
+        // users will have bugs from Meteor's injected line numbers. See:
+        // https://github.com/meteor/meteor/issues/9160
+        var cssMatrixString = `matrix3d( ${ domMatrix.m11 }, ${ domMatrix.m12 }, ${ domMatrix.m13 }, ${ domMatrix.m14 }, ${ domMatrix.m21 }, ${ domMatrix.m22 }, ${ domMatrix.m23 }, ${ domMatrix.m24 }, ${ domMatrix.m31 }, ${ domMatrix.m32 }, ${ domMatrix.m33 }, ${ domMatrix.m34 }, ${ domMatrix.m41 }, ${ domMatrix.m42 }, ${ domMatrix.m43 }, ${ domMatrix.m44 })`;
 
         this.applyStyle('transform', cssMatrixString)
     }

--- a/src/core/Sizeable.js
+++ b/src/core/Sizeable.js
@@ -139,14 +139,6 @@ const SizeableMixin = base => {
         }
 
         _setPropertyXYZ(Class, name, newValue) {
-            if (!(
-                newValue instanceof Object ||
-                newValue instanceof Array ||
-                newValue instanceof Function
-            )) {
-                throw new TypeError(`Invalid value for ${Class.name}#${name}.`)
-            }
-
             if (newValue instanceof Function) {
                 // remove previous task if any.
                 if (!this._propertyFunctions) this._propertyFunctions = new Map
@@ -177,10 +169,13 @@ const SizeableMixin = base => {
                 if (typeof newValue[1] != 'undefined') this._properties[name].y = newValue[1]
                 if (typeof newValue[2] != 'undefined') this._properties[name].z = newValue[2]
             }
-            else {
+            else if (newValue instanceof Object) {
                 if (typeof newValue.x != 'undefined') this._properties[name].x = newValue.x
                 if (typeof newValue.y != 'undefined') this._properties[name].y = newValue.y
                 if (typeof newValue.z != 'undefined') this._properties[name].z = newValue.z
+            }
+            else {
+                throw new TypeError(`Invalid value for ${Class.name}#${name}.`)
             }
         }
 

--- a/src/core/TreeNode.js
+++ b/src/core/TreeNode.js
@@ -37,7 +37,6 @@ const TreeNodeMixin = base => {
          * @param {TreeNode} childNode The child node to add.
          */
         addChild (childNode) {
-
             if (! isInstanceof(childNode, TreeNode))
                 throw new TypeError('TreeNode.addChild expects the childNode argument to be a TreeNode instance.')
 

--- a/src/html/DeclarativeBase.js
+++ b/src/html/DeclarativeBase.js
@@ -115,8 +115,8 @@ export function initDeclarativeBase() {
      * @implements {EventListener}
      */
     DeclarativeBase = class DeclarativeBase extends WebComponent(window.HTMLElement) {
-        createdCallback() {
-            super.createdCallback()
+        constructor() {
+            super()
 
             this.imperativeCounterpart = null // to hold the imperative API Node instance.
 

--- a/src/html/HTMLNode.js
+++ b/src/html/HTMLNode.js
@@ -8,6 +8,9 @@ import DeclarativeBase, {initDeclarativeBase, proxyGettersSetters} from './Decla
 initDeclarativeBase()
 
 class HTMLNode extends DeclarativeBase {
+    static define(name) {
+        customElements.define(name || 'i-node', HTMLNode)
+    }
 
     getStyles() {
         return styles
@@ -29,6 +32,22 @@ class HTMLNode extends DeclarativeBase {
             //console.log(' ------ setAttribute', value)
         super.setAttribute(attribute, ""+value)
     }
+
+    // TODO: get these from somewhere dynamically, and do same for
+    // proxyGettersSetters and _updateNodeProperty
+    static get observedAttributes() { return [
+        'sizeMode',
+        'absoluteSize',
+        'proportionalSize',
+        'align',
+        'mountPoint',
+        'rotation',
+        'position',
+        'scale',
+        'origin',
+        'skew',
+        'opacity',
+    ].map(a => a.toLowerCase())}
 
     attributeChangedCallback(...args) {
         super.attributeChangedCallback(...args)

--- a/src/html/HTMLPushPaneLayout.js
+++ b/src/html/HTMLPushPaneLayout.js
@@ -2,9 +2,8 @@ import HTMLNode from './HTMLNode'
 import PushPaneLayout from '../components/PushPaneLayout'
 
 class HTMLPushPaneLayout extends HTMLNode {
-    createdCallback() {
-        console.log(' -- HTMLPushPaneLayout created')
-        super.createdCallback()
+    static define(name) {
+        customElements.define(name || 'i-push-pane-layout', HTMLPushPaneLayout)
     }
 
     // @override

--- a/src/html/HTMLScene.js
+++ b/src/html/HTMLScene.js
@@ -21,9 +21,12 @@ const _ = instance => {
 }
 
 class HTMLScene extends Observable.mixin(DeclarativeBase) {
+    static define(name) {
+        customElements.define(name || 'i-scene', HTMLScene)
+    }
 
-    createdCallback() {
-        super.createdCallback()
+    constructor() {
+        super()
 
         this._sizePollTask = null
         this._parentSize = {x:0, y:0, z:0}
@@ -35,7 +38,6 @@ class HTMLScene extends Observable.mixin(DeclarativeBase) {
         // childConnectedCallback.
         this._imperativeCounterpartPromise
             .then(() => {
-
                 if (this.imperativeCounterpart._mounted) return
 
                 if (this.parentNode)
@@ -48,7 +50,7 @@ class HTMLScene extends Observable.mixin(DeclarativeBase) {
         // TODO: maybe call this in `init()`, and destroy webgl stuff in
         // `deinit()`.
         // TODO: The user might enable this by setting the attribute later, so
-        // we can't simply rely on having it in createdCallback, we need a
+        // we can't simply rely on having it in constructor, we need a
         // getter/setter like node properties.
         this.initWebGl()
     }

--- a/src/html/index.js
+++ b/src/html/index.js
@@ -4,10 +4,11 @@ import HTMLPushPaneLayout from './HTMLPushPaneLayout'
 import HTMLScene from './HTMLScene'
 import WebComponent from './WebComponent'
 
-import 'document-register-element'
+//import 'document-register-element'
 function useDefaultNames() {
-    document.registerElement('i-node', HTMLNode)
-    document.registerElement('i-scene', HTMLScene)
+    HTMLNode.define()
+    HTMLScene.define()
+    HTMLPushPaneLayout.define()
 }
 
 export {


### PR DESCRIPTION
For this to work, we will not support anything lower than Edge 13, relying on native class syntax. This simplifies the code base a little, and makes it easier to maintain.